### PR TITLE
[WIP] ACLs activated by default to support best practice for Symfony's cache/log dir permissions issue

### DIFF
--- a/overlay/etc/fstab
+++ b/overlay/etc/fstab
@@ -1,0 +1,12 @@
+# /etc/fstab: static file system information.
+#
+# Use 'blkid' to print the universally unique identifier for a
+# device; this may be used with UUID= as a more robust way to name devices
+# that works even if disks are added and removed. See fstab(5).
+#
+# <file system> <mount point> <type> <options> <dump> <pass>
+proc /proc proc nodev,noexec,nosuid 0 0
+/dev/mapper/turnkey-root / ext4 errors=remount-ro,acl 0 1
+# /boot was on /dev/sda1 during installation
+UUID=3baaa7f6-41af-48ea-93c9-a5b3bb8eb4ab /boot ext2 defaults 0 2
+/dev/mapper/turnkey-swap_1 none swap sw 0 0


### PR DESCRIPTION
The best practice (by Symfony) to avoid the file permissions issue for directories `app/cache/` and `app/logs/` is to use utility `setfacl` in Ubuntu (see http://symfony.com/doc/current/book/installation.html#configuration-and-setup section "2. Using Acl on a system that does not support chmod +a" in the box "Setting up Permissions")

For that you have to install the `acl` utilities and adapt your `/etc/fstab` (see https://help.ubuntu.com/community/FilePermissionsACLs). Can we do that for the Symfony appliance? And how? (I am not familiar with TurnKey appliance development, the `/ect/fstab` I added as an overlay is just exemplary.)
