### PR TITLE
Remove duplicate symfony-cli install

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -30,9 +30,6 @@ turnkey-composer require symfony/apache-pack
 turnkey-composer require symfony/orm-pack
 turnkey-composer require --dev symfony/maker-bundle
 
-apt update
-apt install symfony-cli
-
 # for some reason, the symfony/apache-pack doesn't install when run
 # non-interactively, so we'll manually download the .htaccess file
 HTACCESS=public/.htaccess


### PR DESCRIPTION
This doesn't actually do any harm, but it's certainly not of any value and only slows down the build - so worth fixing.

Please note, this was bought to my attention by Alon, so I'm just going to merge it right now.