### PR TITLE
Use composer as root for install

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -23,9 +23,9 @@ symfony new $WEBROOT --version=lts --no-git
 chown -R www-data:www-data $WEBROOT
 cd $WEBROOT
 export COMPOSER_NO_INTERACTION=1
-turnkey-composer require symfony/apache-pack
-turnkey-composer require symfony/orm-pack
-turnkey-composer require --dev symfony/maker-bundle
+composer require symfony/apache-pack
+composer require symfony/orm-pack
+composer require --dev symfony/maker-bundle
 
 # for some reason, the symfony/apache-pack doesn't install when run
 # non-interactively, so we'll manually download the .htaccess file

--- a/conf.d/main
+++ b/conf.d/main
@@ -23,6 +23,7 @@ symfony new $WEBROOT --version=lts --no-git
 chown -R www-data:www-data $WEBROOT
 cd $WEBROOT
 export COMPOSER_NO_INTERACTION=1
+export COMPOSER_ALLOW_SUPERUSER=1
 composer require symfony/apache-pack
 composer require symfony/orm-pack
 composer require --dev symfony/maker-bundle


### PR DESCRIPTION
Work around https://github.com/turnkeylinux/tracker/issues/1960 - by running `composer` as root, rather than using `turnkey-composer`.